### PR TITLE
Fixed opencv dependency to 4.0.1

### DIFF
--- a/dlib/pom.xml
+++ b/dlib/pom.xml
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>opencv</groupId>
             <artifactId>opencv</artifactId>
-            <version>3.4.1</version>
+            <version>4.0.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Hi,

I tried to compile your current master, but it failed withing travis-ci, as there was an outdated reference to opencv 3.4.1.

But there is still another compile error, but I don't know how to fix it.
Could you help me?

```
NFO] 

[INFO] --- build-helper-maven-plugin:3.0.0:add-source (generate-sources) @ dlib ---

[INFO] Source directory: /home/travis/build/deinhofer/dlib-java/dlib/target/generated-sources/swig added.

[INFO] 

[INFO] --- exec-maven-plugin:1.6.0:exec (make-generate-resources) @ dlib ---

 ==> Compiling source files to objects

      - src/main/native/face_descriptor_computer.cpp to target/native/build/face_descriptor_computer.o

Package dlib-1 was not found in the pkg-config search path.

Perhaps you should add the directory containing `dlib-1.pc'

to the PKG_CONFIG_PATH environment variable

No package 'dlib-1' found

Package opencv4 was not found in the pkg-config search path.

Perhaps you should add the directory containing `opencv4.pc'

to the PKG_CONFIG_PATH environment variable

No package 'opencv4' found

src/main/native/face_descriptor_computer.cpp:1:22: fatal error: dlib/dnn.h: No such file or directory

compilation terminated.

[ERROR] Command execution failed.

org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)

    at org.apache.commons.exec.DefaultExecutor.executeInternal (DefaultExecutor.java:404)

    at org.apache.commons.exec.DefaultExecutor.execute (DefaultExecutor.java:166)

    at org.codehaus.mojo.exec.ExecMojo.executeCommandLine (ExecMojo.java:804)

    at org.codehaus.mojo.exec.ExecMojo.executeCommandLine (ExecMojo.java:751)

    at org.codehaus.mojo.exec.ExecMojo.execute (ExecMojo.java:313)

    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)

    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)

    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)

    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)

    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)

    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)

    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)

    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)

    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)

    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)

    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)

    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)

    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)

    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)

    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)

    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)

    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)

    at java.lang.reflect.Method.invoke (Method.java:566)

    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)

    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)

    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)

    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)

[INFO] ------------------------------------------------------------------------

[INFO] Reactor Summary for DLib Parent 1.0-SNAPSHOT:

[INFO] 

[INFO] DLib Parent ........................................ SUCCESS [  0.463 s]

[INFO] DLib ............................................... FAILURE [  1.571 s]

[INFO] DLib Models ........................................ SKIPPED

[INFO] ------------------------------------------------------------------------

[INFO] BUILD FAILURE

[INFO] ------------------------------------------------------------------------

[INFO] Total time:  2.233 s

[INFO] Finished at: 2019-12-04T21:28:18Z

[INFO] ------------------------------------------------------------------------

[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.6.0:exec (make-generate-resources) on project dlib: Command execution failed. Process exited with an error: 1 (Exit value: 1) -> [Help 1]

[ERROR] 

[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.

[ERROR] Re-run Maven using the -X switch to enable full debug logging.

[ERROR] 

[ERROR] For more information about the errors and possible solutions, please read the following articles:

[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException

[ERROR] 

[ERROR] After correcting the problems, you can resume the build with the command

[ERROR]   mvn <goals> -rf :dlib

The command "eval mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V " failed 3 times.

The command "mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V" failed and exited with 1 during .

Your build has been stopped.
``` 